### PR TITLE
Don’t throw on buffer error

### DIFF
--- a/src/Commands/ImportEnvironmentCommand.php
+++ b/src/Commands/ImportEnvironmentCommand.php
@@ -599,12 +599,11 @@ class ImportEnvironmentCommand extends Command
                 $this->newLine(2);
                 $this->info("[Files] {$transferred} file(s) transferred | " . ($total - $transferred) . ' file(s) skipped.');
             }
-
-            // Throw an error if the process fails.
-            if ($type === Process::ERR) {
-                throw new ImportEnvironmentException("rsync failed: {$buffer}");
-            }
         });
+
+        if (!$process->isSuccessful()) {
+            throw new ImportEnvironmentException("rsync failed: {$process->getErrorOutput()}");
+        }
 
         $rsyncEnd = now();
 


### PR DESCRIPTION
Only throw if the command is not successful, instead of on error in the buffer. Console warnings from the remote would be interpreted as errors, which unnecessarily exited the process.