### PR TITLE
Add functionality for email notifications

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -13,4 +13,9 @@ across such a case, please let us know by [opening an issue][issues], or by addi
 * Run `php artisan migrate` to update the database.
 -->
 
+# v0.4.0
+
+* The `sensitive_tables` config key was renamed to `empty_tables`. A fallback has been put in place that will use the
+old key, in case the new key is empty, but it is recommended to update your config.
+
 [issues]: https://github.com/VanOns/laravel-environment-importer/issues

--- a/config/environment-importer.php
+++ b/config/environment-importer.php
@@ -25,7 +25,7 @@ return [
             'db_name' => env('LEI_STAGING_DB_NAME'),
             'db_username' => env('LEI_STAGING_DB_USERNAME'),
             'db_password' => env('LEI_STAGING_DB_PASSWORD'),
-            'db_port' => env('LEI_STAGING_DB_PORT'),
+            'db_port' => env('LEI_STAGING_DB_PORT', '3306'),
             'db_use_ssh' => (bool) env('LEI_STAGING_DB_USE_SSH', false),
             'db_ssh_tunnel_port' => env('LEI_STAGING_DB_SSH_TUNNEL_PORT', '3307'),
 
@@ -43,7 +43,7 @@ return [
             'db_name' => env('LEI_PRODUCTION_DB_NAME'),
             'db_username' => env('LEI_PRODUCTION_DB_USERNAME'),
             'db_password' => env('LEI_PRODUCTION_DB_PASSWORD'),
-            'db_port' => env('LEI_PRODUCTION_DB_PORT'),
+            'db_port' => env('LEI_PRODUCTION_DB_PORT', '3306'),
             'db_use_ssh' => (bool) env('LEI_PRODUCTION_DB_USE_SSH', false),
             'db_ssh_tunnel_port' => env('LEI_PRODUCTION_DB_SSH_TUNNEL_PORT', '3307'),
 

--- a/config/environment-importer.php
+++ b/config/environment-importer.php
@@ -12,9 +12,7 @@ return [
     */
 
     'environments' => [
-
         'staging' => [
-
             'ssh_host' => env('LEI_STAGING_SSH_HOST'),
             'ssh_username' => env('LEI_STAGING_SSH_USERNAME'),
             'ssh_key' => env('LEI_STAGING_SSH_KEY', '~/.ssh/id_rsa'),
@@ -28,11 +26,9 @@ return [
             'db_port' => env('LEI_STAGING_DB_PORT', '3306'),
             'db_use_ssh' => (bool) env('LEI_STAGING_DB_USE_SSH', false),
             'db_ssh_tunnel_port' => env('LEI_STAGING_DB_SSH_TUNNEL_PORT', '3307'),
-
         ],
 
         'production' => [
-
             'ssh_host' => env('LEI_PRODUCTION_SSH_HOST'),
             'ssh_username' => env('LEI_PRODUCTION_SSH_USERNAME'),
             'ssh_key' => env('LEI_PRODUCTION_SSH_KEY', '~/.ssh/id_rsa'),
@@ -46,9 +42,7 @@ return [
             'db_port' => env('LEI_PRODUCTION_DB_PORT', '3306'),
             'db_use_ssh' => (bool) env('LEI_PRODUCTION_DB_USE_SSH', false),
             'db_ssh_tunnel_port' => env('LEI_PRODUCTION_DB_SSH_TUNNEL_PORT', '3307'),
-
         ],
-
     ],
 
     /*
@@ -139,6 +133,31 @@ return [
 
         // If you want to provide patterns for users to be preserved:
         // \VanOns\LaravelEnvironmentImporter\Processors\AnonymizeUsers::class => ['@example.com'],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Notifications
+    |--------------------------------------------------------------------------
+    |
+    | Here you can define the notifications that should be sent in specific
+    | situations. You can define the types of notifications and the routes
+    | that should be used to send them.
+    |
+    */
+
+    'notifications' => [
+        'types' => [
+            'import_succeeded' => env('LEI_NOTIFY_IMPORT_SUCCEEDED', false),
+            'import_failed' => env('LEI_NOTIFY_IMPORT_FAILED', false),
+        ],
+
+        'routes' => [
+            /**
+             * Comma-separated list of email addresses to send the notifications to. Leave empty to disable.
+             */
+            'mail' => explode(',', env('LEI_NOTIFY_MAIL', '')),
+        ],
     ],
 
 ];

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -15,3 +15,8 @@ The command supports the following flags:
 | `--clean`      | Skip all prompts and clean up all files after import |
 | `--skip-db`    | Skip importing the database                          |
 | `--skip-files` | Skip importing the files                             |
+
+## Notifications
+
+It is possible to receive email notifications when the import succeeds or fails. To do that, make sure to configure
+the `notifications` section in the configuration file.

--- a/src/Commands/ImportEnvironmentCommand.php
+++ b/src/Commands/ImportEnvironmentCommand.php
@@ -780,6 +780,6 @@ class ImportEnvironmentCommand extends Command
 
     protected function dbPort(): string
     {
-        return $this->getEnvironmentConfigValue('db_port');
+        return $this->getEnvironmentConfigValue('db_port', '3306');
     }
 }

--- a/src/Notifications/ImportFailed.php
+++ b/src/Notifications/ImportFailed.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace VanOns\LaravelEnvironmentImporter\Notifications;
+
+use Carbon\Carbon;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\HtmlString;
+
+class ImportFailed extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        protected Carbon $startedAt,
+        protected Carbon $failedAt,
+        protected string $exception
+    ) {}
+
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->subject('Environment not imported')
+            ->line('The environment import was not successful. Please find the details below.')
+            ->line(new HtmlString('<strong>Started at:</strong> ' . $this->startedAt->toString()))
+            ->line(new HtmlString('<strong>Failed at:</strong> ' . $this->failedAt->toString()))
+            ->line(new HtmlString('<strong>Exception:</strong> ' . $this->exception));
+    }
+}

--- a/src/Notifications/ImportSucceeded.php
+++ b/src/Notifications/ImportSucceeded.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace VanOns\LaravelEnvironmentImporter\Notifications;
+
+use Carbon\Carbon;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\HtmlString;
+
+class ImportSucceeded extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        protected Carbon $startedAt,
+        protected Carbon $finishedAt,
+    ) {}
+
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->subject('Environment imported successfully')
+            ->line('The environment import was successful! Please find the details below.')
+            ->line(new HtmlString('<strong>Started at:</strong> ' . $this->startedAt->toString()))
+            ->line(new HtmlString('<strong>Finished at:</strong> ' . $this->finishedAt->toString()));
+    }
+}


### PR DESCRIPTION
## Features

- Added support for email notifications, with the following configuration options:
    - If success notifications should be sent
    - If failure notifications should be sent
    - The email addresses the notifications should be sent to
- Added default database port `'3306'`
- Added documentation