### PR TITLE
Add support for configurable email domain and password override

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -19,7 +19,7 @@ across such a case, please let us know by [opening an issue][issues], or by addi
   that it follows the following format:
   ```php
   \VanOns\LaravelEnvironmentImporter\Processors\AnonymizeUsers::class => [
-      'preserve_emails' => ['@example.com'],
+      'preserve_emails' => ['@example.com', 'john@doe.com'],
       'email_domain' => 'example.com',
       'password_override' => 'password',
   ]

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -13,7 +13,19 @@ across such a case, please let us know by [opening an issue][issues], or by addi
 * Run `php artisan migrate` to update the database.
 -->
 
-# v0.4.0
+## v0.5.0
+
+* The configuration for the `AnonymizeUsers` processor has changed. Make sure to update your config file accordingly, so
+  that it follows the following format:
+  ```php
+  \VanOns\LaravelEnvironmentImporter\Processors\AnonymizeUsers::class => [
+      'preserve_emails' => ['@example.com'],
+      'email_domain' => 'example.com',
+      'password_override' => 'password',
+  ]
+  ```
+
+## v0.4.0
 
 * The `sensitive_tables` config key was renamed to `empty_tables`. A fallback has been put in place that will use the
 old key, in case the new key is empty, but it is recommended to update your config.

--- a/config/environment-importer.php
+++ b/config/environment-importer.php
@@ -133,7 +133,7 @@ return [
 
         // This processor supports the following options:
         //\VanOns\LaravelEnvironmentImporter\Processors\AnonymizeUsers::class => [
-        //    'preserve_emails' => ['@example.com'],
+        //    'preserve_emails' => ['@example.com', 'john@doe.com'],
         //    'email_domain' => 'example.com',
         //    'password_override' => 'password',
         //],

--- a/config/environment-importer.php
+++ b/config/environment-importer.php
@@ -131,8 +131,12 @@ return [
     'data_processors' => [
         \VanOns\LaravelEnvironmentImporter\Processors\AnonymizeUsers::class,
 
-        // If you want to provide patterns for users to be preserved:
-        // \VanOns\LaravelEnvironmentImporter\Processors\AnonymizeUsers::class => ['@example.com'],
+        // This processor supports the following options:
+        //\VanOns\LaravelEnvironmentImporter\Processors\AnonymizeUsers::class => [
+        //    'preserve_emails' => ['@example.com'],
+        //    'email_domain' => 'example.com',
+        //    'password_override' => 'password',
+        //],
     ],
 
     /*

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,31 +1,18 @@
 # Installation
 
-While the package is for internal use only, you can install it from GitHub. Add the following to your `composer.json`:
-
-```json
-{
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/VanOns/laravel-environment-importer"
-        }
-    ]
-}
-```
-
-Then, install the package:
+First, install the package via Composer:
 
 ```bash
 composer require van-ons/laravel-environment-importer
 ```
 
-Next, publish the configuration file:
+Then, publish the configuration file:
 
 ```bash
 php artisan vendor:publish --tag="environment-importer-config"
 ```
 
-Finally, open the configuration file (`config/environment-importer.php`) and adjust it to your needs.
+Next, open the configuration file (`config/environment-importer.php`) and adjust it to your needs.
 
 ## Configuration
 


### PR DESCRIPTION
## Features

- Added support for configurable email domain (`email_domain` key)
- Added support for configurable password override (`password_override` key)
- Moved preservation emails to `preserve_emails` key